### PR TITLE
Add simple API server and use configured backend URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "node server.js"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,105 @@
+/* eslint-env node */
+import { createServer } from 'http';
+
+const PORT = process.env.PORT || 3000;
+
+let message = 'Hello from the backend';
+let clients = [
+  {
+    id: 1,
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+    membershipType: 'Community Arc',
+    status: 'active',
+    lastSignIn: 'Just now',
+    program: 'New Program',
+    avatar: 'JD'
+  }
+];
+const payments = [
+  {
+    id: 'pay_1',
+    customer: 'cust_1',
+    status: 'succeeded',
+    amount: 1000,
+    currency: 'USD',
+    created: new Date().toISOString()
+  }
+];
+
+function sendJson(res, data) {
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(data));
+}
+
+function handleRequest(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  if (req.method === 'GET' && req.url === '/api') {
+    return sendJson(res, { message: 'API is running' });
+  }
+
+  if (req.url === '/api/message') {
+    if (req.method === 'GET') {
+      return sendJson(res, { message });
+    }
+    if (req.method === 'POST') {
+      const { newMessage } = req.body || {};
+      if (typeof newMessage === 'string') message = newMessage;
+      return sendJson(res, { success: true, message });
+    }
+  }
+
+  if (req.url === '/api/clients') {
+    if (req.method === 'GET') {
+      return sendJson(res, clients);
+    }
+    if (req.method === 'POST') {
+      const newClient = { id: Date.now(), ...(req.body || {}) };
+      clients.push(newClient);
+      return sendJson(res, newClient);
+    }
+  }
+
+  if (req.url && req.url.startsWith('/api/clients/') && req.method === 'PUT') {
+    const id = parseInt(req.url.split('/').pop(), 10);
+    const idx = clients.findIndex(c => c.id === id);
+    if (idx === -1) {
+      res.writeHead(404);
+      return sendJson(res, { error: 'Client not found' });
+    }
+    clients[idx] = { ...clients[idx], ...(req.body || {}) };
+    return sendJson(res, clients[idx]);
+  }
+
+  if (req.method === 'GET' && req.url === '/api/payments') {
+    return sendJson(res, payments);
+  }
+
+  res.writeHead(404);
+  res.end('Not found');
+}
+
+createServer((req, res) => {
+  let body = '';
+  req.on('data', chunk => {
+    body += chunk;
+  });
+  req.on('end', () => {
+    try {
+      req.body = body ? JSON.parse(body) : {};
+    } catch {
+      req.body = {};
+    }
+    handleRequest(req, res);
+  });
+}).listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/src/API/config.js
+++ b/src/API/config.js
@@ -1,1 +1,1 @@
-export const BACKEND_URL = 'https://herarcbackend.onrender.com';
+export const BACKEND_URL = "https://herarcbackend.onrender.com";

--- a/src/Client Components/Clients.jsx
+++ b/src/Client Components/Clients.jsx
@@ -30,7 +30,7 @@ function Clients() {
   useEffect(() => {
     const fetchClients = async () => {
       try {
-        const response = await fetch('https://herarcbackend.onrender.com/api/clients');
+        const response = await fetch(`${BACKEND_URL}/api/clients`);
         const data = await response.json();
         console.log("Fetched clients:", data);
         setClients(data);
@@ -47,7 +47,7 @@ function Clients() {
   const fetchClients = async () => {
     try {
       setLoading(true);
-      const response = await fetch('http://herarcbackend.onrender.com/api/clients');
+      const response = await fetch(`${BACKEND_URL}/api/clients`);
       if (response.ok) {
         const data = await response.json();
         setClients(data);
@@ -73,7 +73,7 @@ function Clients() {
     e.preventDefault();
     
     try {
-      const response = await fetch('http://herarcbackend.onrender.com/api/clients', {
+      const response = await fetch(`${BACKEND_URL}/api/clients`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -130,7 +130,7 @@ function Clients() {
     e.preventDefault();
     
     try {
-      const response = await fetch(`http://herarcbackend.onrender.com/api/clients/${editingClient.id}`, {
+      const response = await fetch(`${BACKEND_URL}/api/clients/${editingClient.id}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/src/Payments.jsx
+++ b/src/Payments.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import axios from 'axios';
+import { BACKEND_URL } from './API/config';
 
 export default function Payments() {
   const [payments, setPayments] = useState([]);
@@ -11,7 +12,7 @@ export default function Payments() {
     (async () => {
       try {
         // Use your live backend URL to dodge proxy/CORS weirdness.
-        const res = await axios.get('https://herarcbackend.onrender.com/api/payments', { timeout: 15000 });
+        const res = await axios.get(`${BACKEND_URL}/api/payments`, { timeout: 15000 });
         const data = Array.isArray(res.data) ? res.data : [];
         if (isMounted) setPayments(data);
       } catch (e) {

--- a/src/Team.jsx
+++ b/src/Team.jsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
+import { BACKEND_URL } from './API/config';
 
 function WebMessageSender() {
   const [input, setInput] = useState('');
 
   const sendMessage = () => {
-    fetch('http://localhost:3000/api/message', {
+    fetch(`${BACKEND_URL}/api/message`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ newMessage: input }),


### PR DESCRIPTION
## Summary
- add a lightweight Node HTTP server exposing `/api` endpoints for messages, clients and payments
- standardize frontend API calls around a shared `BACKEND_URL`
- add `start` script for launching the server

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 130 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a21cd04bc83229d0684ad04564662